### PR TITLE
feat: set up Next.js configuration

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  typescript: {
+    tsconfigPath: './tsconfig.json',
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,17 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
-    "build": "vite build && npx cap sync",
-    "sync": "npx cap sync",
-    "open:xcode": "npx cap open ios",
-    "open:android-studio": "npx cap open android",
-    "start:ios": "npx cap sync && npx cap run ios",
-    "start:android": "npx cap sync && npx cap run android",
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "ui:add": "pnpx shadcn-ui@latest add"
   },
   "devDependencies": {
-    "@capacitor/cli": "^7.0.1",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
@@ -26,23 +21,18 @@
     "vite": "^5.4.14"
   },
   "dependencies": {
-    "@capacitor/android": "^7.0.1",
-    "@capacitor/camera": "^7.0.0",
-    "@capacitor/core": "^7.0.1",
-    "@capacitor/ios": "^7.0.1",
-    "@capacitor/splash-screen": "^7.0.0",
     "@clerk/clerk-react": "^5.41.0",
     "@clerk/localizations": "^3.20.9",
-    "@ionic/pwa-elements": "^3.3.0",
     "@radix-ui/react-icons": "^1.3.2",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.15.0",
     "konsta": "^4.0.1",
+    "next": "^14.2.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.29.0",
+    "@clerk/nextjs": "^5.41.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,13 +6,12 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    /* Next.js mode */
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
 
     /* Linting */
     "strict": true,
@@ -24,8 +23,10 @@
       "@components/*": ["./src/components/*"],
       "$assets/*": ["./src/assets/*"],
       "$utils": ["./src/lib/utils.ts"]
-    }
+    },
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["src"],
+  "include": ["next-env.d.ts", "src", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add Next.js configuration with strict mode
- replace Vite/Capacitor scripts with Next commands
- adjust TypeScript config and update dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - @clerk/nextjs)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8b7cf4b4832b8921f5f7ae0b3f60